### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -73,9 +73,9 @@ export async function showSystemNotification(options: NotificationOptions): Prom
 
 		const escapedOptions = {
 			...options,
-			title: title.replace(/"/g, '\\"'),
-			message: message.replace(/"/g, '\\"'),
-			subtitle: options.subtitle?.replace(/"/g, '\\"') || "",
+			title: title.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			message: message.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			subtitle: options.subtitle?.replace(/\\/g, '\\\\').replace(/"/g, '\\"') || "",
 		}
 
 		switch (platform()) {


### PR DESCRIPTION
Potential fix for [https://github.com/justinlietz93/Apex-CodeGenesis/security/code-scanning/9](https://github.com/justinlietz93/Apex-CodeGenesis/security/code-scanning/9)

To fix the problem, we need to ensure that backslashes are also escaped in addition to double-quote characters. This can be achieved by using a regular expression with the `g` flag to replace all occurrences of backslashes with double backslashes, and then replacing double-quote characters. This approach ensures that both backslashes and double-quote characters are properly escaped.

We will update the `showSystemNotification` function to include the additional escaping for backslashes. Specifically, we will modify the `escapedOptions` object to replace backslashes with double backslashes before replacing double-quote characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
