### PR TITLE
Potential fix for code scanning alert no. 26: Incomplete URL substring sanitization

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -222,7 +222,8 @@ export class OpenAiHandler implements ApiHandler {
 		// Azure API shape slightly differs from the core API shape: https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai
 		// Use azureApiVersion to determine if this is an Azure endpoint, since the URL may not always contain 'azure.com'
 		const url = new URL(this.options.openAiBaseUrl);
-		if (this.options.azureApiVersion || url.host.endsWith('azure.com')) {
+		const isAzureHost = url.host === 'azure.com' || url.host.endsWith('.azure.com');
+		if (this.options.azureApiVersion || isAzureHost) {
 			this.client = new AzureOpenAI({
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,


### PR DESCRIPTION
Potential fix for [https://github.com/justinlietz93/Apex-CodeGenesis/security/code-scanning/26](https://github.com/justinlietz93/Apex-CodeGenesis/security/code-scanning/26)

To fix the issue, we need to ensure that the host is either `azure.com` or a valid subdomain of `azure.com`. This can be achieved by parsing the URL and explicitly checking that the host ends with `.azure.com` or is exactly `azure.com`. The `.azure.com` suffix ensures that only subdomains of `azure.com` are allowed, while excluding malicious hosts like `malicious-azure.com`.

The fix involves:
1. Parsing the `url.host` and ensuring it matches the allowed domain structure.
2. Replacing the `url.host.endsWith('azure.com')` check with a more robust validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
